### PR TITLE
Links for installation had errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ First: install Ruby on your machine!
 After that: to install the gem:
 
     gem install specific_install
-    gem specific_install http://github.com/bugmark/bmx_api_ruby
-    gem specific_install http://github.com/bugmark/bmx_cl_ruby
+    gem specific_install https://github.com/bugmark/bmx_api_ruby
+    gem specific_install https://github.com/bugmark/bmx_cl_ruby
     
 ## Usage
 


### PR DESCRIPTION
The links installation for gem had an error "unable to access 'http://github.com/bugmark/bmx_api_ruby.git/': Could not resolve host: github.com" because of the link in the command
